### PR TITLE
Frontend changes in Workspace page corresponding to SN-181

### DIFF
--- a/src/redux/actions/api/WorkspaceDetails/AddAnnotatorsToWorkspace.js
+++ b/src/redux/actions/api/WorkspaceDetails/AddAnnotatorsToWorkspace.js
@@ -12,7 +12,7 @@ export default class AddAnnotatorsToWorkspaceAPI extends API {
     this.emails = userEmails;
     this.endpoint = `${super.apiEndPointAuto()}${
       ENDPOINTS.getWorkspaces
-    }${workspaceId}/addannotators/`;
+    }${workspaceId}/addmembers/`;
   }
 
   processResponse(res) {

--- a/src/redux/actions/api/WorkspaceDetails/GetWorkspaceAnnotators.js
+++ b/src/redux/actions/api/WorkspaceDetails/GetWorkspaceAnnotators.js
@@ -9,7 +9,7 @@ import constants from "../../../constants";
    constructor(workspaceId, timeout = 2000) {
      super("GET", timeout, false);
      this.type = constants. GET_WORKSPACE_ANNOTATORS_DATA;
-     this.endpoint = `${super.apiEndPointAuto()}${ENDPOINTS.getWorkspaces}${workspaceId}/users/`;
+     this.endpoint = `${super.apiEndPointAuto()}${ENDPOINTS.getWorkspaces}${workspaceId}/members/`;
    }
  
    processResponse(res) {

--- a/src/ui/pages/component/common/AddUsersDialog.jsx
+++ b/src/ui/pages/component/common/AddUsersDialog.jsx
@@ -68,7 +68,7 @@ const getAvailableUsers = (userType, projectDetails, workspaceAnnotators, worksp
               (annotator) => annotator?.id === orgUser?.id
             ) === -1
         )
-        .map((user) => ({ email: user.email, username: user.username }));
+        .map((user) => ({ email: user.email, username: user.username, id: user.id }));
       break;
     case addUserTypes.MANAGER:
       return orgUsers
@@ -110,7 +110,7 @@ const handleAddUsers = async (userType, users, id, dispatch) => {
     case addUserTypes.ANNOTATOR:
       const addAnnotatorsObj = new AddAnnotatorsToWorkspaceAPI(
         id,
-        users.map((user) => user.email).join(','),
+        users.map((user) => user.id).join(','),
       );
       const addAnnotatorsRes = await fetch(addAnnotatorsObj.apiEndPoint(), {
         method: "POST",

--- a/src/ui/pages/component/common/DetailsViewPage.jsx
+++ b/src/ui/pages/component/common/DetailsViewPage.jsx
@@ -114,7 +114,7 @@ const DetailsViewPage = (props) => {
                             {pageType === componentType.Type_Workspace && <Tab label={translate("label.projects")} sx={{ fontSize: 16, fontWeight: '700' }} />}
                             {pageType === componentType.Type_Organization && <Tab label={translate("label.workspaces")} sx={{ fontSize: 16, fontWeight: '700' }} />}
 
-                            {pageType === componentType.Type_Workspace && <Tab label={translate("label.annotators")} sx={{ fontSize: 16, fontWeight: '700' }} />}
+                            {pageType === componentType.Type_Workspace && <Tab label={translate("label.members")} sx={{ fontSize: 16, fontWeight: '700' }} />}
                             {pageType === componentType.Type_Organization && <Tab label={translate("label.members")} sx={{ fontSize: 16, fontWeight: '700' }} />}
 
 
@@ -170,7 +170,7 @@ const DetailsViewPage = (props) => {
                         {pageType === componentType.Type_Workspace &&
                             <>
                                 
-                                <Button className={classes.annotatorsButton} label={"Add Annotators to Workspace"}sx={{ width: "100%", mb: 2 }} onClick={handleAnnotatorDialogOpen} />
+                                <Button className={classes.annotatorsButton} label={"Add Members to Workspace"}sx={{ width: "100%", mb: 2 }} onClick={handleAnnotatorDialogOpen} />
                                 <AnnotatorsTable />
                                 <AddUsersDialog
                                     handleDialogClose={handleAnnotatorDialogClose}


### PR DESCRIPTION
- [x] Rename 'Annotators' tab to 'Members' 
- [x] Rename 'Add annotators to Workspace' to 'Add members to Workspace'
- [x] Make sure the frontend invokes the correct endpoints after the functions renaming in points 1 & 2 under Workspace → Backend section