### PR TITLE
fix: add_project_users should sends ids

### DIFF
--- a/src/redux/actions/api/ProjectDetails/AddMembersToProject.js
+++ b/src/redux/actions/api/ProjectDetails/AddMembersToProject.js
@@ -28,7 +28,7 @@ export default class AddMembersToProjectAPI extends API {
 
   getBody() {
     return {
-      emails: this.ids,
+      ids: this.ids,
     };
   }
 

--- a/src/ui/pages/component/common/AddUsersDialog.jsx
+++ b/src/ui/pages/component/common/AddUsersDialog.jsx
@@ -61,7 +61,7 @@ const getAvailableUsers = (userType, projectDetails, workspaceAnnotators, worksp
               (projectUser) => projectUser?.id === workspaceAnnotator?.id
             ) === -1
         )
-        .map((user) => ({ email: user.email, username: user.username }));
+        .map((user) => ({ id: user.id, email: user.email, username: user.username }));
       break;
       case addUserTypes.PROJECT_REVIEWER:
         return workspaceAnnotators
@@ -91,7 +91,7 @@ const getAvailableUsers = (userType, projectDetails, workspaceAnnotators, worksp
               (manager) => manager?.id === orgUser?.id
             ) === -1
         )
-        .map((user) => ({ email: user.email, username: user.username }));
+        .map((user) => ({ id: user.id, email: user.email, username: user.username }));
       break;
     default:
       break;


### PR DESCRIPTION
`ids` will be sent to the backend instead of `emails`