### PR TITLE
Fix persist project tabs through redux

### DIFF
--- a/src/redux/actions/Tasks/ProjectTabActions.js
+++ b/src/redux/actions/Tasks/ProjectTabActions.js
@@ -1,0 +1,6 @@
+export const SET_TAB_VALUE = "SET_TAB_VALUE";
+
+export const setValue = (value) => ({
+  type: SET_TAB_VALUE,
+  payload: value,
+});

--- a/src/redux/reducers/ProjectDetails/ProjectTabReducer.js
+++ b/src/redux/reducers/ProjectDetails/ProjectTabReducer.js
@@ -1,0 +1,19 @@
+import { SET_TAB_VALUE } from "../../actions/Tasks/ProjectTabActions";
+
+const initialState = {
+  value: 0,
+};
+
+const projectReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_TAB_VALUE:
+      return {
+        ...state,
+        value: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+export default projectReducer;

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -98,6 +98,7 @@ import commonReducer from "./CL-Transcription/Common";
 import getAnnotationsTask from "./CL-Transcription/GetAnnotationsTask";
 import patchAnnotation from "./CL-Transcription/PatchAnnotation"
 import updateUIPrefs from "./UserManagement/UpdateUIPrefs";
+import projectTabReducer from "./ProjectDetails/ProjectTabReducer";
 
 
 const index = {
@@ -204,6 +205,7 @@ const index = {
     patchAnnotation,
     updateUIPrefs,
     getManagerSuggestions,
+    projectTab:projectTabReducer
 };
 
 export default index;

--- a/src/ui/pages/container/Project/ProjectDetails.jsx
+++ b/src/ui/pages/container/Project/ProjectDetails.jsx
@@ -35,6 +35,7 @@ import userRole from "../../../../utils/UserMappedByRole/Roles";
 import SuperCheckerTasks from "../../component/Project/SuperCheckerTasks";
 import SuperChecker from "../../component/Project/SuperChecker";
 import ProjectAnalytics from "../../component/Project/ProjectAnalytics";
+import { setValue } from "../../../../redux/actions/Tasks/ProjectTabActions";
 
 const menuOptions = [
   { name: "Tasks", isChecked: false, component: () => null },
@@ -180,9 +181,9 @@ const Projects = () => {
   }, [ProjectDetails.id]);
   const [loading, setLoading] = useState(false);
   const [annotationreviewertype, setAnnotationreviewertype] = useState();
-  const [value, setValue] = React.useState(0);
+  const value = useSelector((state) => state.projectTab.value);
   const handleChange = (event, newValue) => {
-    setValue(newValue);
+    dispatch(setValue(newValue));
   };
   const apiLoading = useSelector((state) => state.apiStatus.loading);
 


### PR DESCRIPTION
This PR ensures that the state of the tabs inside the Project Detail Page persists across page reloads or navigation through redux.