### PR TITLE
Fix persist filter project datasets page with hover tooltip

### DIFF
--- a/src/ui/pages/container/Dataset/DatasetCard.jsx
+++ b/src/ui/pages/container/Dataset/DatasetCard.jsx
@@ -9,6 +9,9 @@ import Spinner from "../../component/common/Spinner";
 import { useNavigate } from "react-router-dom";
 import DatasetFilterList from "./DatasetFilterList";
 import FilterListIcon from "@mui/icons-material/FilterList";
+import InfoIcon from '@mui/icons-material/Info';
+import { tooltipClasses } from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
 
 
 const DatasetCards = (props) => {
@@ -70,15 +73,51 @@ const DatasetCards = (props) => {
   //     setLoading(apiLoading);
   // }, [apiLoading])
 
+    const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+  console.log("filtersApplied", filtersApplied);
+
+    const CustomTooltip = styled(({ className, ...props }) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+      ))(({ theme }) => ({
+        [`& .${tooltipClasses.tooltip}`]: {
+          backgroundColor: '#e0e0e0',
+          color: 'rgba(0, 0, 0, 0.87)',
+          maxWidth: 300,
+          fontSize: theme.typography.pxToRem(12),
+        },
+        [`& .${tooltipClasses.arrow}`]: {
+          color: "#e0e0e0",
+        },
+      }));
+
   return (
     <React.Fragment>
       {/* <Header /> */}
       {/* {loading && <Spinner />} */}
       <Grid sx={{textAlign:"end",margin:"-20px 10px 10px 0px"}}>
         <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
-        <Tooltip title={"Filter Table"}>
-          <FilterListIcon sx={{ color: "#515A5A" }} />
-        </Tooltip>
+        {filtersApplied && <InfoIcon color="primary" fontSize="small" sx={{position:"absolute", top:-4, right:-4}}/>}
+          <CustomTooltip
+            title={
+              filtersApplied ? (
+                <Box style={{ fontFamily: 'Roboto, sans-serif' }} sx={{ padding: '5px', maxWidth: '300px', fontSize: '12px', display:"flex",flexDirection:"column", gap:"5px" }}>
+                  {selectedFilters.dataset_type && <div><strong>Dataset Type:</strong> {selectedFilters.dataset_type}</div>}
+                  {selectedFilters.dataset_visibility && <div><strong>Dataset Visibility:</strong> {selectedFilters.dataset_visibility}</div>}
+              </Box>
+            ) : (
+            <span style={{ fontFamily: 'Roboto, sans-serif' }}>
+              Filter Table
+            </span>
+            )  
+            }
+            disableInteractive
+          >
+            <FilterListIcon sx={{ color: '#515A5A' }} />
+          </CustomTooltip>
       </Button>
       </Grid>
       {pageSearch().length > 0 && (

--- a/src/ui/pages/container/Dataset/DatasetCardList.jsx
+++ b/src/ui/pages/container/Dataset/DatasetCardList.jsx
@@ -13,6 +13,9 @@ import tableTheme from "../../../theme/tableTheme";
 import {  useSelector } from "react-redux";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import DatasetFilterList from "./DatasetFilterList";
+import InfoIcon from '@mui/icons-material/Info';
+import { tooltipClasses } from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
 
 
 const DatasetCardList = (props) => {
@@ -117,13 +120,47 @@ const DatasetCardList = (props) => {
         })
       : [];
 
+        const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+  const CustomTooltip = styled(({ className, ...props }) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+      ))(({ theme }) => ({
+        [`& .${tooltipClasses.tooltip}`]: {
+          backgroundColor: '#e0e0e0',
+          color: 'rgba(0, 0, 0, 0.87)',
+          maxWidth: 300,
+          fontSize: theme.typography.pxToRem(12),
+        },
+        [`& .${tooltipClasses.arrow}`]: {
+          color: "#e0e0e0",
+        },
+      }));
+
   const renderToolBar = () => {
     return (
       <>
-        <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
-          <Tooltip title={"Filter Table"}>
-            <FilterListIcon sx={{ color: "#515A5A" }} />
-          </Tooltip>
+        <Button style={{position: "relative", minWidth: "25px" }} onClick={handleShowFilter}>
+        {filtersApplied && <InfoIcon color="primary" fontSize="small" sx={{position:"absolute", top:-4, right:-4}}/>}        
+           <CustomTooltip
+            title={
+              filtersApplied ? (
+                <Box style={{ fontFamily: 'Roboto, sans-serif' }} sx={{ padding: '5px', maxWidth: '300px', fontSize: '12px', display:"flex",flexDirection:"column", gap:"5px" }}>
+                  {selectedFilters.dataset_type && <div><strong>Dataset Type:</strong> {selectedFilters.dataset_type}</div>}
+                  {selectedFilters.dataset_visibility && <div><strong>Dataset Visibility:</strong> {selectedFilters.dataset_visibility}</div>}
+              </Box>
+            ) : (
+            <span style={{ fontFamily: 'Roboto, sans-serif' }}>
+              Filter Table
+            </span>
+            )  
+            }
+            disableInteractive
+          >
+            <FilterListIcon sx={{ color: '#515A5A' }} />
+          </CustomTooltip>
         </Button>
       </>
     );

--- a/src/ui/pages/container/Dataset/DatasetList.jsx
+++ b/src/ui/pages/container/Dataset/DatasetList.jsx
@@ -25,9 +25,11 @@ export default function DatasetList() {
   const datasetList = useSelector((state) => state.getDatasetList.data);
   const apiLoading = useSelector((state) => state.apiStatus.loading);
 
-  const [selectedFilters, setsSelectedFilters] = useState({
-    dataset_visibility: "",
-    dataset_type: "",
+  const [selectedFilters, setsSelectedFilters] = useState(() => {
+  const savedFilters = localStorage.getItem("datasetSelectedFilters");
+    return savedFilters
+      ? JSON.parse(savedFilters)
+      : { dataset_visibility: "", dataset_type: "" };
   });
   const getDashboardprojectData = () => {
     const projectObj = new GetDatasetsAPI(selectedFilters);
@@ -41,6 +43,13 @@ export default function DatasetList() {
 
   useEffect(() => {
     getDashboardprojectData();
+  }, [selectedFilters]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      "datasetSelectedFilters",
+      JSON.stringify(selectedFilters),
+    );
   }, [selectedFilters]);
 
   const handleProjectlist = () => {

--- a/src/ui/pages/container/Project/ProjectCard.jsx
+++ b/src/ui/pages/container/Project/ProjectCard.jsx
@@ -13,6 +13,9 @@ import { useNavigate } from "react-router-dom";
 import ProjectFilterList from "../../component/common/ProjectFilterList";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import UserMappedByProjectStage from "../../../../utils/UserMappedByRole/UserMappedByProjectStage";
+import InfoIcon from '@mui/icons-material/Info';
+import { tooltipClasses } from '@mui/material/Tooltip';
+import { styled } from '@mui/material/styles';
 
 
 const Projectcard = (props) => {
@@ -76,13 +79,49 @@ const Projectcard = (props) => {
     });
   };
 
+  const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+
+  const CustomTooltip = styled(({ className, ...props }) => (
+    <Tooltip {...props} classes={{ popper: className }} />
+      ))(({ theme }) => ({
+        [`& .${tooltipClasses.tooltip}`]: {
+          backgroundColor: '#e0e0e0',
+          color: 'rgba(0, 0, 0, 0.87)',
+          maxWidth: 300,
+          fontSize: theme.typography.pxToRem(12),
+        },
+        [`& .${tooltipClasses.arrow}`]: {
+          color: "#e0e0e0",
+        },
+  }));
+
   return (
     <React.Fragment>
         <Grid sx={{textAlign:"end",margin:"-20px 10px 10px 0px"}}>
         <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
-        <Tooltip title={"Filter Table"}>
-          <FilterListIcon sx={{ color: "#515A5A" }} />
-        </Tooltip>
+        {filtersApplied && <InfoIcon color="primary" fontSize="small" sx={{position:"absolute", top:-4, right:-4}}/>}
+          <CustomTooltip
+            title={
+              filtersApplied ? (
+                <Box style={{ fontFamily: 'Roboto, sans-serif' }} sx={{ padding: '5px', maxWidth: '300px', fontSize: '12px', display:"flex",flexDirection:"column", gap:"5px" }}>
+                  {selectedFilters.project_type && <div><strong>Project Type:</strong> {selectedFilters.project_type}</div>}
+                  {selectedFilters.project_user_type && <div><strong>Project User Type:</strong> {selectedFilters.project_user_type}</div>}
+                  {selectedFilters.archived_projects && <div><strong>Archived Projects:</strong> {selectedFilters.archived_projects}</div>}
+              </Box>
+            ) : (
+            <span style={{ fontFamily: 'Roboto, sans-serif' }}>
+              Filter Table
+            </span>
+            )  
+            }
+            disableInteractive
+          >
+            <FilterListIcon sx={{ color: '#515A5A' }} />
+          </CustomTooltip>
       </Button>
       </Grid>
       {pageSearch().length > 0 ? (

--- a/src/ui/pages/container/Project/ProjectCardList.jsx
+++ b/src/ui/pages/container/Project/ProjectCardList.jsx
@@ -14,6 +14,9 @@ import {  useSelector } from "react-redux";
 import ProjectFilterList from "../../component/common/ProjectFilterList";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import UserMappedByProjectStage from "../../../../utils/UserMappedByRole/UserMappedByProjectStage";
+import { styled } from '@mui/material/styles';
+import InfoIcon from '@mui/icons-material/Info';
+import { tooltipClasses } from '@mui/material/Tooltip';
 
 const ProjectCardList = (props) => {
   const { projectData, selectedFilters, setsSelectedFilters } = props;
@@ -198,13 +201,49 @@ const ProjectCardList = (props) => {
         })
       : [];
 
+  const areFiltersApplied = (filters) => {
+    return Object.values(filters).some((value) => value !== "");
+  };
+
+  const filtersApplied = areFiltersApplied(selectedFilters);
+
+  const CustomTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+    ))(({ theme }) => ({
+      [`& .${tooltipClasses.tooltip}`]: {
+        backgroundColor: '#e0e0e0',
+        color: 'rgba(0, 0, 0, 0.87)',
+        maxWidth: 350,
+        fontSize: theme.typography.pxToRem(12),
+      },
+      [`& .${tooltipClasses.arrow}`]: {
+        color: "#e0e0e0",
+      },
+}));
+
   const renderToolBar = () => {
     return (
       <>
-        <Button style={{ minWidth: "25px" }} onClick={handleShowFilter}>
-          <Tooltip title={"Filter Table"}>
-            <FilterListIcon sx={{ color: "#515A5A" }} />
-          </Tooltip>
+        <Button style={{position: "relative", minWidth: "25px" }} onClick={handleShowFilter}>
+        {filtersApplied && <InfoIcon color="primary" fontSize="small" sx={{position:"absolute", top:-4, right:-4}}/>}        
+          <CustomTooltip
+            title={
+              filtersApplied ? (
+                <Box style={{ fontFamily: 'Roboto, sans-serif' }} sx={{ padding: '5px', maxWidth: '350px', fontSize: '12px', display:"flex",flexDirection:"column", gap:"5px" }}>
+                  {selectedFilters.project_type && <div><strong>Project Type:</strong> {selectedFilters.project_type}</div>}
+                  {selectedFilters.project_user_type && <div><strong>Project User Type:</strong> {selectedFilters.project_user_type}</div>}
+                  {selectedFilters.archived_projects && <div><strong>Archived Projects:</strong> {selectedFilters.archived_projects}</div>}
+              </Box>
+            ) : (
+            <span style={{ fontFamily: 'Roboto, sans-serif' }}>
+              Filter Table
+            </span>
+            )  
+            }
+            disableInteractive
+          >
+            <FilterListIcon sx={{ color: '#515A5A' }} />
+          </CustomTooltip>
         </Button>
       </>
     );

--- a/src/ui/pages/container/Project/ProjectList.jsx
+++ b/src/ui/pages/container/Project/ProjectList.jsx
@@ -19,11 +19,15 @@ export default function ProjectList() {
   const classes = DatasetStyle();
   const dispatch = useDispatch();
   const [loading, setLoading] = useState(false);
-  const [selectedFilters, setsSelectedFilters] = useState({
-    project_type: "",
-    project_user_type: "",
-    archived_projects: "",
-  });
+  const [selectedFilters, setsSelectedFilters] = useState(() => {
+    const savedFilters = localStorage.getItem("projectSelectedFilters");
+    return savedFilters
+      ? JSON.parse(savedFilters)
+      : {
+          project_type: "",
+          project_user_type: "",
+          archived_projects: "",
+        }});
   const apiLoading = useSelector((state) => state.apiStatus.loading);
   const projectData = useSelector((state) => state.getProjects.data);
   
@@ -39,6 +43,13 @@ export default function ProjectList() {
 
   useEffect(() => {
     getDashboardprojectData();
+  }, [selectedFilters]);
+
+  useEffect(() => {
+    localStorage.setItem(
+      "projectSelectedFilters",
+      JSON.stringify(selectedFilters),
+    );
   }, [selectedFilters]);
 
   const handleProjectlist = () => {


### PR DESCRIPTION
This PR introduces several improvements to the Project and Dataset pages. 

- First, the filter persistence feature is implemented, ensuring that the active filters remain persisted, enhancing the user experience. 
- Additionally, hover effects and an info icon are also added to the cards as well as list, improving user interaction and making the interface more intuitive.