### PR TITLE
Fix doublehash tlp shortcut

### DIFF
--- a/src/ui/pages/component/CL-Transcription/SettingsButtonComponent.jsx
+++ b/src/ui/pages/component/CL-Transcription/SettingsButtonComponent.jsx
@@ -255,7 +255,8 @@ ProjectDetails,
             }}
             trigger={
               <FormControlLabel
-                label="&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Hotkeys Explorer"
+                sx={{paddingLeft:"48px"}}
+                label="Hotkeys Explorer"
                 control={<div></div>}
               />
             }
@@ -283,8 +284,12 @@ ProjectDetails,
                 <li>Play/Pause - Shift + Space</li>
                 <li>Seek Left - Shift + &#8592;</li>
                 <li>Seek Right - Shift + &#8594;</li>
+                <li>Select Text Left - Shift + &lt;</li>
+                <li>Select Text Right - Shift + &lt;</li>
                 <li>Noise Tags - $$$</li>
                 <li>Toggle Transliteration - Alt + 1</li>
+                <li>Undo - Ctrl + Z</li>
+                <li>Redu - Ctrl + Y</li>
                 {/* <li>Color Schema set</li> */}
               </ul>
             </div>

--- a/src/ui/pages/container/CL-Transcription/AllAudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/AllAudioTranscriptionLandingPage.jsx
@@ -527,12 +527,7 @@ const AllAudioTranscriptionLandingPage = () => {
           }
         }
       }
-      const activeElement = document.activeElement;
-      const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-
-      if (isTextAreaFocused) {
-        return;
-      }
+      
       if (event.shiftKey && event.key === 'ArrowLeft') {
         event.preventDefault();
         if (player) {

--- a/src/ui/pages/container/CL-Transcription/AudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/AudioTranscriptionLandingPage.jsx
@@ -980,12 +980,7 @@ useEffect(() => {
         }
       }
     }
-    const activeElement = document.activeElement;
-    const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-
-    if (isTextAreaFocused) {
-      return;
-    }
+    
     if (event.shiftKey && event.key === 'ArrowLeft') {
       event.preventDefault();
       if(player){

--- a/src/ui/pages/container/CL-Transcription/ReviewAudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/ReviewAudioTranscriptionLandingPage.jsx
@@ -1169,12 +1169,7 @@ useEffect(() => {
         }
       }
     }
-    const activeElement = document.activeElement;
-    const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-
-    if (isTextAreaFocused) {
-      return;
-    }
+    
     if (event.shiftKey && event.key === 'ArrowLeft') {
       event.preventDefault();
       if(player){

--- a/src/ui/pages/container/CL-Transcription/SuperCheckerAudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/SuperCheckerAudioTranscriptionLandingPage.jsx
@@ -1021,12 +1021,7 @@ useEffect(() => {
         }
       }
     }
-    const activeElement = document.activeElement;
-    const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-
-    if (isTextAreaFocused) {
-      return;
-    }
+    
     if (event.shiftKey && event.key === 'ArrowLeft') {
       event.preventDefault();
       if(player){


### PR DESCRIPTION
Updated shortcut from (ctrl + ->) to < and >, fixed the undo and redo functionality on the transcription right panel to properly track text edits like double hash insertion, enhanced hotkey shortcuts for seek navigation, and added support for undo/redo in the double hash , using keyboard commands.