### PR TITLE
Fix doublehash tlp shortcut

### DIFF
--- a/src/ui/pages/component/CL-Transcription/SettingsButtonComponent.jsx
+++ b/src/ui/pages/component/CL-Transcription/SettingsButtonComponent.jsx
@@ -255,7 +255,8 @@ ProjectDetails,
             }}
             trigger={
               <FormControlLabel
-                label="&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Hotkeys Explorer"
+                sx={{paddingLeft:"48px"}}
+                label="Hotkeys Explorer"
                 control={<div></div>}
               />
             }
@@ -283,8 +284,12 @@ ProjectDetails,
                 <li>Play/Pause - Shift + Space</li>
                 <li>Seek Left - Shift + &#8592;</li>
                 <li>Seek Right - Shift + &#8594;</li>
+                <li>Select Text Left - Shift + &lt;</li>
+                <li>Select Text Right - Shift + &lt;</li>
                 <li>Noise Tags - $$$</li>
                 <li>Toggle Transliteration - Alt + 1</li>
+                <li>Undo - Ctrl + Z</li>
+                <li>Redu - Ctrl + Y</li>
                 {/* <li>Color Schema set</li> */}
               </ul>
             </div>

--- a/src/ui/pages/container/CL-Transcription/AllAudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/AllAudioTranscriptionLandingPage.jsx
@@ -527,13 +527,7 @@ const AllAudioTranscriptionLandingPage = () => {
           }
         }
       }
-      const activeElement = document.activeElement;
-      const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-      console.log(activeElement);
-
-      if (isTextAreaFocused) {
-        return;
-      }
+      
       if (event.shiftKey && event.key === 'ArrowLeft') {
         event.preventDefault();
         if (player) {

--- a/src/ui/pages/container/CL-Transcription/AudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/AudioTranscriptionLandingPage.jsx
@@ -982,13 +982,7 @@ useEffect(() => {
         }
       }
     }
-    const activeElement = document.activeElement;
-    const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-    console.log(activeElement);
-
-    if (isTextAreaFocused) {
-      return;
-    }
+    
     if (event.shiftKey && event.key === 'ArrowLeft') {
       event.preventDefault();
       if(player){

--- a/src/ui/pages/container/CL-Transcription/ReviewAudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/ReviewAudioTranscriptionLandingPage.jsx
@@ -1174,13 +1174,7 @@ useEffect(() => {
         }
       }
     }
-    const activeElement = document.activeElement;
-    const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-    console.log(activeElement);
-
-    if (isTextAreaFocused) {
-      return;
-    }
+    
     if (event.shiftKey && event.key === 'ArrowLeft') {
       event.preventDefault();
       if(player){

--- a/src/ui/pages/container/CL-Transcription/SuperCheckerAudioTranscriptionLandingPage.jsx
+++ b/src/ui/pages/container/CL-Transcription/SuperCheckerAudioTranscriptionLandingPage.jsx
@@ -1027,13 +1027,7 @@ useEffect(() => {
         }
       }
     }
-    const activeElement = document.activeElement;
-    const isTextAreaFocused = activeElement.tagName =='TEXTAREA';
-    console.log(activeElement);
-
-    if (isTextAreaFocused) {
-      return;
-    }
+    
     if (event.shiftKey && event.key === 'ArrowLeft') {
       event.preventDefault();
       if(player){

--- a/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
+++ b/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
@@ -551,6 +551,16 @@ const TranscriptionRightPanel = ({
       const doubleHashedText = `##${selectedText}##`;
 
       replaceSelectedText(doubleHashedText, currentIndexToSplitTextBlock, index);
+      setUndoStack((prevState) => [
+        ...prevState,
+        {
+          type: "doubleHash",
+          index: i,
+          originalText: selectedText,
+          hashedText: doubleHashedText,
+        },
+      ]);
+      setRedoStack([]);
     }
   }
 
@@ -580,10 +590,32 @@ const TranscriptionRightPanel = ({
     if (undoStack?.length > 0) {
       //getting last last action performed by user
       const lastAction = undoStack[undoStack?.length - 1];
+      if (lastAction.type === "doubleHash") {
+      // Undo the double-hash action
+      const elementsWithBoxHighlightClass = document.getElementsByClassName(
+        classes.boxHighlight
+      );
+      const textArea = elementsWithBoxHighlightClass[lastAction.index];
+    if (textArea) {
+        textArea.value = textArea.value.replace(
+          lastAction.hashedText,
+          lastAction.originalText
+        );
+
+        // Update the subtitles state
+        const sub = onSubtitleChange(
+          textArea.value,
+          currentIndexToSplitTextBlock,
+          lastAction.index
+        );
+        dispatch(setSubtitles(sub, C.SUBTITLES));
+      }
+    } else {
 
       // modifing subtitles based on last action
       const sub = onUndoAction(lastAction);
       dispatch(setSubtitles(sub, C.SUBTITLES));
+    }
 
       //removing the last action from undo and putting in redo stack
       setUndoStack(undoStack.slice(0, undoStack?.length - 1));
@@ -597,10 +629,31 @@ const TranscriptionRightPanel = ({
     if (redoStack?.length > 0) {
       //getting last last action performed by user
       const lastAction = redoStack[redoStack?.length - 1];
+      if (lastAction.type === "doubleHash") {
+      // Redo the double-hash action
+      const elementsWithBoxHighlightClass = document.getElementsByClassName(
+        classes.boxHighlight
+      );
+      const textArea = elementsWithBoxHighlightClass[lastAction.index];
+      if (textArea) {
+        textArea.value = textArea.value.replace(
+          lastAction.originalText,
+          lastAction.hashedText
+        );
 
+        // Update the subtitles state
+        const sub = onSubtitleChange(
+          textArea.value,
+          currentIndexToSplitTextBlock,
+          lastAction.index
+        );
+        dispatch(setSubtitles(sub, C.SUBTITLES));
+      }
+    } else {
       // modifing subtitles based on last action
       const sub = onRedoAction(lastAction);
       dispatch(setSubtitles(sub, C.SUBTITLES));
+    }
 
       //removing the last action from redo and putting in undo stack
       setRedoStack(redoStack.slice(0, redoStack?.length - 1));
@@ -609,6 +662,23 @@ const TranscriptionRightPanel = ({
 
     // eslint-disable-next-line
   }, [undoStack, redoStack]);
+
+  useEffect(() => {
+      const handleKeyDown = (event) => {
+        if (event.ctrlKey && event.key === "z") {
+          event.preventDefault();
+          onUndo();
+        } else if (event.ctrlKey && event.key === "y") {
+          event.preventDefault();
+          onRedo();
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => {
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }, [onUndo, onRedo]);
 
   const targetLength = (index) => {
     if (subtitles[index]?.text?.trim() !== "")
@@ -1015,7 +1085,7 @@ const TranscriptionRightPanel = ({
                           onKeyDown={(event) => {
                             console.log(event,"log",document.activeElement);
 
-                            if ( event.shiftKey && event.key == "ArrowLeft") {
+                            if ( event.shiftKey && event.key == "<") {
                               const textArea = textRefs.current[index];
                               console.log("helo");
 
@@ -1028,7 +1098,7 @@ const TranscriptionRightPanel = ({
                                 event.preventDefault(); 
                               }
                             }
-                            else if (event.shiftKey && event.key == "ArrowRight") {
+                            else if (event.shiftKey && event.key == ">") {
                               const textArea = textRefs.current[index];
                               if (textArea) {
                                 const start = textArea.selectionStart;
@@ -1092,7 +1162,7 @@ const TranscriptionRightPanel = ({
                                   onKeyDown={(event) => {
                                     console.log(event,"log",document.activeElement);
         
-                                    if ( event.shiftKey && event.key == "ArrowLeft") {
+                                    if ( event.shiftKey && event.key == "<") {
                                       const textArea = textRefs.current[index];
                                       console.log("helo");
         
@@ -1105,7 +1175,7 @@ const TranscriptionRightPanel = ({
                                         event.preventDefault(); 
                                       }
                                     }
-                                    else if (event.shiftKey && event.key == "ArrowRight") {
+                                    else if (event.shiftKey && event.key == ">") {
                                       const textArea = textRefs.current[index];
                                       if (textArea) {
                                         const start = textArea.selectionStart;
@@ -1180,7 +1250,7 @@ const TranscriptionRightPanel = ({
                             onKeyDown={(event) => {
                               console.log(event,"log",document.activeElement);
   
-                              if ( event.shiftKey && event.key == "ArrowLeft") {
+                              if ( event.shiftKey && event.key == "<") {
                                 const textArea = textRefs.current[index];
                                 console.log("helo");
   
@@ -1193,7 +1263,7 @@ const TranscriptionRightPanel = ({
                                   event.preventDefault(); 
                                 }
                               }
-                              else if (event.shiftKey && event.key == "ArrowRight") {
+                              else if (event.shiftKey && event.key == ">") {
                                 const textArea = textRefs.current[index];
                                 if (textArea) {
                                   const start = textArea.selectionStart;
@@ -1266,7 +1336,7 @@ const TranscriptionRightPanel = ({
                             onKeyDown={(event) => {
                               console.log(event,"log",document.activeElement);
   
-                              if ( event.shiftKey && event.key == "ArrowLeft") {
+                              if ( event.shiftKey && event.key == "<") {
                                 const textArea = textRefs.current[index];
                                 console.log("helo");
   
@@ -1279,7 +1349,7 @@ const TranscriptionRightPanel = ({
                                   event.preventDefault(); 
                                 }
                               }
-                              else if (event.shiftKey && event.key == "ArrowRight") {
+                              else if (event.shiftKey && event.key == ">") {
                                 const textArea = textRefs.current[index];
                                 if (textArea) {
                                   const start = textArea.selectionStart;
@@ -1348,7 +1418,7 @@ const TranscriptionRightPanel = ({
                                     onKeyDown={(event) => {
                                       console.log(event,"log",document.activeElement);
           
-                                      if ( event.shiftKey && event.key == "ArrowLeft") {
+                                      if ( event.shiftKey && event.key == "<") {
                                         const textArea = textRefs.current[index];
                                         console.log("helo");
           
@@ -1361,7 +1431,7 @@ const TranscriptionRightPanel = ({
                                           event.preventDefault(); 
                                         }
                                       }
-                                      else if (event.shiftKey && event.key == "ArrowRight") {
+                                      else if (event.shiftKey && event.key == ">") {
                                         const textArea = textRefs.current[index];
                                         if (textArea) {
                                           const start = textArea.selectionStart;
@@ -1431,7 +1501,7 @@ const TranscriptionRightPanel = ({
                               onKeyDown={(event) => {
                                 console.log(event,"log",document.activeElement);
     
-                                if ( event.shiftKey && event.key == "ArrowLeft") {
+                                if ( event.shiftKey && event.key == "<") {
                                   const textArea = textRefs.current[index];
                                   console.log("helo");
     
@@ -1444,7 +1514,7 @@ const TranscriptionRightPanel = ({
                                     event.preventDefault(); 
                                   }
                                 }
-                                else if (event.shiftKey && event.key == "ArrowRight") {
+                                else if (event.shiftKey && event.key == ">") {
                                   const textArea = textRefs.current[index];
                                   if (textArea) {
                                     const start = textArea.selectionStart;


### PR DESCRIPTION
Updated shortcut from (ctrl + ->) to < and >, fixed the undo and redo functionality on the transcription right panel to properly track text edits like double hash insertion, enhanced hotkey shortcuts for seek navigation, and added support for undo/redo in the double hash , using keyboard commands.