### PR TITLE
feat: add condition to skip processNoiseTags for multiref projects

### DIFF
--- a/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
+++ b/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
@@ -481,8 +481,10 @@ const changeTranscriptHandler = (event, index, updateAcoustic = false) => {
 
   // value = processMultiHypothesisText(value);
   
-  // Apply noise tag processing
-  value = processNoiseTags(value);
+  // Apply noise tag processing only if project title doesn't include "multiref"
+  if (!ProjectDetails?.title || !ProjectDetails.title.toLowerCase().includes("multiref")) {
+    value = processNoiseTags(value);
+  }
 
   if (updateAcoustic && !(ProjectDetails?.metadata_json?.copy_l1_to_l2 ?? true)) {
     const verbatimText = subtitles[index]?.text || "";


### PR DESCRIPTION
- Modified changeTranscriptHandler to check if project title contains 'multiref'
- If project title includes 'multiref', processNoiseTags is skipped
- This allows multiref projects to bypass noise tag processing
- Maintains existing behavior for non-multiref projects