### PR TITLE
feat: Auto-select first text region on page load for OCRTranscription…

### DIFF
--- a/src/ui/pages/container/Label-Studio/LSF.jsx
+++ b/src/ui/pages/container/Label-Studio/LSF.jsx
@@ -416,6 +416,14 @@ const LabelStudioWrapper = ({
             });
             ls.annotationStore.selectAnnotation(c.id);
           }
+          if (projectType.includes("OCRTranscriptionEditing")) {
+            setTimeout(() => {
+              const annotation = ls.annotationStore.selected;
+              if (annotation && annotation.regionStore && annotation.regionStore.regions && annotation.regionStore.regions.length > 0) {
+                annotation.selectArea(annotation.regionStore.regions[0]);
+              }
+            }, 500);
+          }
           load_time.current = new Date();
         },
 

--- a/src/ui/pages/container/Label-Studio/ReviewLSF.jsx
+++ b/src/ui/pages/container/Label-Studio/ReviewLSF.jsx
@@ -481,6 +481,14 @@ useEffect(() => {
           //   ls.annotationStore.selectAnnotation(c.id);
           // }
           // }
+          if (projectType.includes("OCRTranscriptionEditing")) {
+            setTimeout(() => {
+              const annotation = ls.annotationStore.selected;
+              if (annotation && annotation.regionStore && annotation.regionStore.regions && annotation.regionStore.regions.length > 0) {
+                annotation.selectArea(annotation.regionStore.regions[0]);
+              }
+            }, 500);
+          }
           load_time.current = new Date();
         },
 

--- a/src/ui/pages/container/Label-Studio/SuperCheckerLSF.jsx
+++ b/src/ui/pages/container/Label-Studio/SuperCheckerLSF.jsx
@@ -394,6 +394,14 @@ useEffect(() => {
           //   ls.annotationStore.selectAnnotation(c.id);
           // }
           // }
+          if (projectType.includes("OCRTranscriptionEditing")) {
+            setTimeout(() => {
+              const annotation = ls.annotationStore.selected;
+              if (annotation && annotation.regionStore && annotation.regionStore.regions && annotation.regionStore.regions.length > 0) {
+                annotation.selectArea(annotation.regionStore.regions[0]);
+              }
+            }, 500);
+          }
           load_time.current = new Date();
         },
 


### PR DESCRIPTION
feat: Auto-select first text region on page load for OCRTranscriptionEditing

- Automatically select the first region from regionStore when page loads
- Display selected text in ocr_transcribed_json textarea without user click
- Applied to LSF, ReviewLSF, and SuperCheckerLSF components
- Includes 500ms delay to ensure regions are fully loaded