### PR TITLE
feat(dataset): display remaining unassigned items count in project creation and dataset details

### DIFF
--- a/src/ui/pages/container/Dataset/CreateDatasetAndProject.jsx
+++ b/src/ui/pages/container/Dataset/CreateDatasetAndProject.jsx
@@ -81,6 +81,7 @@ const CreateDatasetAndProject = () => {
   const [workspaceId, setWorkspaceId] = useState("");
   const [category, setCategory] = useState("");
   const [projectResult, setProjectResult] = useState(null);
+  const [datasetStats, setDatasetStats] = useState(null);
 
   const showError = (message) => setSnackbar({ open: true, message, variant: "error" });
   const showInfo = (message) => setSnackbar({ open: true, message, variant: "info" });
@@ -150,6 +151,30 @@ const CreateDatasetAndProject = () => {
       cancelled = true;
     };
   }, [useExistingDataset, existingInstanceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Create Project tab: how many of the selected dataset's items are still
+  // unassigned (not yet pulled into any project), per category -- so the
+  // user can see what's actually left before picking a category/clicking.
+  const fetchDatasetStats = async (instanceId) => {
+    if (!instanceId) {
+      setDatasetStats(null);
+      return;
+    }
+    try {
+      const res = await fetch(
+        `${baseUrl()}${ENDPOINTS.getDatasets}instances/${instanceId}/pipeline_dataset_stats/`,
+        { headers: authHeaders() }
+      );
+      const data = await res.json();
+      setDatasetStats(res.ok ? data.categories : null);
+    } catch {
+      setDatasetStats(null);
+    }
+  };
+
+  useEffect(() => {
+    fetchDatasetStats(projectInstanceId);
+  }, [projectInstanceId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ---- Dataset tab / Step 1: upload + validate ----
   const handleFileChange = async (e) => {
@@ -337,6 +362,7 @@ const CreateDatasetAndProject = () => {
           ...(data.topped_up_projects || []),
         ],
       }));
+      fetchDatasetStats(projectInstanceId);
     } catch (err) {
       showError(err.message || "Failed to create project(s)");
     } finally {
@@ -708,6 +734,30 @@ const CreateDatasetAndProject = () => {
             </Select>
           </FormControl>
         </Grid>
+
+        {projectInstanceId && (
+          <Grid item xs={12}>
+            {datasetStats === null ? (
+              <Typography variant="body2" color="text.secondary">
+                Loading remaining item counts…
+              </Typography>
+            ) : Object.keys(datasetStats).length === 0 ? (
+              <Typography variant="body2" color="text.secondary">
+                This dataset has no items yet.
+              </Typography>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                Remaining (not yet in any project):{" "}
+                {Object.entries(datasetStats)
+                  .map(
+                    ([cat, { unassigned, total }]) =>
+                      `${cat}: ${unassigned} / ${total}`
+                  )
+                  .join("  |  ")}
+              </Typography>
+            )}
+          </Grid>
+        )}
 
         <Grid item xs={12} md={6}>
           <FormControl fullWidth>

--- a/src/ui/pages/container/Dataset/DatasetDetails.jsx
+++ b/src/ui/pages/container/Dataset/DatasetDetails.jsx
@@ -19,6 +19,8 @@ import DatasetDescription from './DatasetDescription';
 import userRole from "../../../../utils/UserMappedByRole/Roles";
 import DatasetReports from '../../component/common/DatasetReports';
 import Spinner from '../../component/common/Spinner';
+import config from "../../../../config/config";
+import ENDPOINTS from "../../../../config/apiendpoint";
 
 const DatasetDetails = () => {
 
@@ -30,9 +32,10 @@ const DatasetDetails = () => {
         [
             { name: "Dataset ID", value: null },
             { name: "Description", value: null },
-            { name: "dataset Type", value: null },    
+            { name: "dataset Type", value: null },
         ]
     )
+    const [remainingText, setRemainingText] = useState(null);
   const apiLoading = useSelector((state) => state.apiStatus.loading);
 
     const dispatch = useDispatch();
@@ -70,6 +73,52 @@ const DatasetDetails = () => {
            
         ])
     }, [DatasetDetails.instance_id]);
+
+    // "Remaining (not yet in any project)" -- per-category (Read/Extempore)
+    // when the dataset has them, otherwise one combined count across the
+    // whole dataset regardless of category.
+    useEffect(() => {
+        if (!datasetId) {
+            setRemainingText(null);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch(
+                    `${config.BASE_URL_AUTO}${ENDPOINTS.getDatasets}instances/${datasetId}/pipeline_dataset_stats/`,
+                    {
+                        headers: {
+                            Authorization: `JWT ${localStorage.getItem("shoonya_access_token")}`,
+                        },
+                    }
+                );
+                if (!res.ok) {
+                    if (!cancelled) setRemainingText(null);
+                    return;
+                }
+                const data = await res.json();
+                if (cancelled) return;
+                const categories = data.categories || {};
+                if (Object.keys(categories).length > 0) {
+                    setRemainingText(
+                        Object.entries(categories)
+                            .map(([cat, { unassigned, total }]) => `${cat}: ${unassigned} / ${total}`)
+                            .join("  |  ")
+                    );
+                } else if (data.combined) {
+                    setRemainingText(`${data.combined.unassigned} / ${data.combined.total}`);
+                } else {
+                    setRemainingText(null);
+                }
+            } catch {
+                if (!cancelled) setRemainingText(null);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [datasetId]);
 
     const handleOpenSettings = () => {
         // navigate(`/projects/${id}/projectsetting`);
@@ -167,6 +216,23 @@ const DatasetDetails = () => {
                                     />
                                 </Grid>
                             ))}
+                            {remainingText !== null && (
+                                <Grid item xs={4} sm={4} md={4} lg={4} xl={4}>
+                                    <DatasetDescription
+                                        name={
+                                            <>
+                                                Remaining
+                                                <br />
+                                                <Typography component="span" variant="caption" color="text.secondary">
+                                                    (not yet in any project)
+                                                </Typography>
+                                            </>
+                                        }
+                                        value={remainingText}
+                                        index={datasetData.length}
+                                    />
+                                </Grid>
+                            )}
                         </Grid>
                     </Grid>
                     <Box >


### PR DESCRIPTION
- **Create Project View Stats:** The Create Project tab now automatically fetches and displays the "Remaining" (unassigned) item count for the selected dataset before the user commits to creating a project. It also dynamically refreshes this count after new projects are successfully created or topped up.
- **Dataset Details Summary:** A new "Remaining (not yet in any project)" metrics block has been added to the main Dataset Details page to provide quick at-a-glance insight into dataset capacity.


### UI Changes
* Users selecting a dataset from the dropdown in the Create Project wizard will now see a subtext label: e.g., `Remaining (not yet in any project): Read: 50 / 1050 | Extempore: 200 / 1200`.
* The Dataset Details dashboard features a new stat tile showing the exact same unassigned breakdown.