### PR TITLE
fix(ui): update speaker label format and improve dataset details responsiveness

### DIFF
--- a/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
+++ b/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
@@ -1697,7 +1697,7 @@ const changeTranscriptHandler = (event, index, updateAcoustic = false) => {
                         >
                           {speakerIdList?.map((speaker, index) => (
                             <MenuItem key={index} value={speaker.name}>
-                              {speaker.name} ({speaker.gender})
+                              Speaker {speaker.speaker_id}
                             </MenuItem>
                           ))}
                         </Select>

--- a/src/ui/pages/container/Dataset/DatasetDescription.jsx
+++ b/src/ui/pages/container/Dataset/DatasetDescription.jsx
@@ -25,7 +25,7 @@ const DatasetDescription = (props) => {
     return (
         <ThemeProvider theme={themeDefault}>
 
-<Card  style={{ minHeight: '100px', maxHeight: '100px',backgroundColor: ImageArray[index].color ,display: 'flex'}}>
+<Card  style={{ minHeight: '100px',backgroundColor: ImageArray[index].color ,display: 'flex'}}>
             <Grid container >
                 <Grid item xs={3} sm={3} md={3} lg={3} xl={3} style={{ display: 'flex', marginTop: "21px", justifyContent: 'center', }}>
                     <div className={classes.descCardIcon} style={{  color: ImageArray[index].iconColor, backgroundColor: ImageArray[index].color }}>

--- a/src/ui/pages/container/Dataset/DatasetDetails.jsx
+++ b/src/ui/pages/container/Dataset/DatasetDetails.jsx
@@ -208,7 +208,7 @@ const DatasetDetails = () => {
                      <Grid item xs={12} sm={12} md={12} lg={12} xl={12}  sx={{ mb: 2 ,mt:3}}>
                         <Grid container spacing={2}>
                             {datasetData?.map((des, i) => (
-                                <Grid item xs={4} sm={4} md={4} lg={4} xl={4}>
+                                <Grid item xs={12} sm={6} md={4}>
                                     <DatasetDescription
                                         name={des.name}
                                         value={des.value}
@@ -217,7 +217,7 @@ const DatasetDetails = () => {
                                 </Grid>
                             ))}
                             {remainingText !== null && (
-                                <Grid item xs={4} sm={4} md={4} lg={4} xl={4}>
+                                <Grid item xs={12} sm={6} md={4}>
                                     <DatasetDescription
                                         name={
                                             <>

--- a/src/ui/styles/Dataset.js
+++ b/src/ui/styles/Dataset.js
@@ -229,7 +229,7 @@ const DatasetStyle = makeStyles({
     lineHeight: "22px",
     "&:first-letter": { textTransform: "capitalize" },
     display: "-webkit-box",
-    "-webkit-line-clamp": "2",
+    "-webkit-line-clamp": "4",
     "-webkit-box-orient": "vertical",
     overflow: "hidden",
     "@media (max-width:400px)": {


### PR DESCRIPTION
## Description

This PR introduces UI refinements to improve the responsiveness of the Dataset Details view and updates the speaker labeling format in the transcription panel.

### New Features & Enhancements
- **Speaker Label Formatting:** Updated the speaker selection dropdown in the transcription right panel (`TranscriptionRightPanel.jsx`). The label now displays as `Speaker {speaker_id}` instead of showing the speaker's name and gender.

### Bug Fixes & UI Improvements
- **Improved Grid Responsiveness:** Adjusted the grid layout in the Dataset Details view (`DatasetDetails.jsx`). The stats cards now respond dynamically to screen sizes (`xs={12} sm={6} md={4}`) instead of being forced into a rigid, non-responsive 3-column layout.
- **Dynamic Card Heights:** Removed a hardcoded `maxHeight` constraint from the `DatasetDescription` card, allowing it to naturally expand and properly contain its contents.
- **Extended Text Visibility:** Increased the `-webkit-line-clamp` property for dataset descriptions from `2` to `4` lines (`Dataset.js`). This allows users to read more of the description before the text gets truncated with an ellipsis.

### UI Changes
* Speaker dropdown now reads: `Speaker 0`, `Speaker 1`, etc.
* Dataset Details cards now stack neatly on mobile screens and expand flexibly on larger screens.
* Longer descriptions on cards now show up to 4 lines of text.

