### PR TITLE
fix(ui): add bidirectional phoneme mappings for Marathi transcription

### DIFF
--- a/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
+++ b/src/ui/pages/container/CL-Transcription/TranscriptionRightPanel.jsx
@@ -86,11 +86,11 @@ const languageTagMappings = {
     'ഫ': ['ph-f', 'f-ph'] // f vs ph
   },
   'mr': {
-    'ज': ['z-j'],   // j vs z
-    'झ': ['zh-jh'], // jh vs zh
-    'च': ['ts-ch'], // ch vs ts
+    'ज': ['z-j', 'j-z'],     // j vs z
+    'झ': ['zh-jh', 'jh-zh'], // jh vs zh
+    'च': ['ts-ch', 'ch-ts'], // ch vs ts
     'ஃப' /* not used */: undefined, // placeholder removed below
-    'फ': ['ph-f']   // f vs ph
+    'फ': ['ph-f', 'f-ph']    // f vs ph
   },
   'en': {
     'ज़': ['zh-z', 'zh-j'] // zh vs z / j context-based


### PR DESCRIPTION
## Description
This PR improves the phoneme substitution logic in the transcription panel by introducing bidirectional mappings for Marathi characters. 

### Enhancements
- **Marathi Bidirectional Mapping:** Updated `languageTagMappings` in `TranscriptionRightPanel.jsx` to ensure certain Marathi phonemes are mapped both ways. Previously, translations only mapped one direction (e.g., `z-j`). This change adds the inverse pairs (e.g., `j-z`, `jh-zh`, `ch-ts`, `f-ph`) to allow for completely fluid corrections during Marathi transcription tasks. 
